### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 
 [macOS (10.7及以上)] (https://raw.githubusercontent.com/getlantern/lantern-binaries/master/lantern-installer-beta.dmg)              [备用地址] (https://s3.amazonaws.com/lantern/lantern-installer-beta.dmg) 
 
-#蓝灯官方中文论坛请访问 https://github.com/getlantern/forum
+# 蓝灯官方中文论坛请访问 https://github.com/getlantern/forum


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
